### PR TITLE
Import .zct/.hct theme archives on open and route to existing instance

### DIFF
--- a/src/common/outbound.c
+++ b/src/common/outbound.c
@@ -3955,6 +3955,28 @@ cmd_voice (struct session *sess, char *tbuf, char *word[], char *word_eol[])
 	}
 }
 
+static int
+cmd_themeimport (struct session *sess, char *tbuf, char *word[], char *word_eol[])
+{
+	char *path = NULL;
+
+	if (word_eol[2] == NULL || word_eol[2][0] == '\0')
+		return FALSE;
+
+	if (g_str_has_prefix (word_eol[2], "file://"))
+		path = g_filename_from_uri (word_eol[2], NULL, NULL);
+	else
+		path = g_strdup (word_eol[2]);
+
+	if (path == NULL)
+		return FALSE;
+
+	zoitechat_theme_import (sess, path);
+	g_free (path);
+
+	return TRUE;
+}
+
 /* *MUST* be kept perfectly sorted for the bsearch to work */
 const struct commands xc_cmds[] = {
 	{"ADDBUTTON", cmd_addbutton, 0, 0, 1,
@@ -4136,6 +4158,8 @@ const struct commands xc_cmds[] = {
 	{"SETTAB", cmd_settab, 0, 0, 1, N_("SETTAB <new name>, change a tab's name, tab_trunc limit still applies")},
 	{"SETTEXT", cmd_settext, 0, 0, 1, N_("SETTEXT <new text>, replace the text in the input box")},
 	{"SPLAY", cmd_splay, 0, 0, 1, "SPLAY <soundfile>"},
+	{"THEMEIMPORT", cmd_themeimport, 0, 0, 1,
+	 N_("THEMEIMPORT <file>, imports a theme archive into the themes folder")},
 	{"TOPIC", cmd_topic, 1, 1, 1,
 	 N_("TOPIC [<topic>], sets the topic if one is given, else shows the current topic")},
 	{"TRAY", cmd_tray, 0, 0, 1,

--- a/src/common/zoitechat.h
+++ b/src/common/zoitechat.h
@@ -626,4 +626,6 @@ struct popup
 /* CL: get a random int in the range [0..n-1]. DON'T use rand() % n, it gives terrible results. */
 #define RAND_INT(n) ((int)(rand() / (RAND_MAX + 1.0) * (n)))
 
+int zoitechat_theme_import (struct session *sess, const char *theme_path);
+
 #endif


### PR DESCRIPTION
### Motivation
- When ZoiteChat is launched with a theme archive (`.zct` or `.hct`) the app should import the theme automatically rather than treating the argument as an IRC URL. 
- If an instance is already running, the existing instance should perform the import rather than launching a new window on Windows. 
- Theme archives are ZIPs and must be extracted into a folder named after the theme (filename without extension) inside the `themes` directory, and imports should be robust across platforms.

### Description
- Add theme import helpers and implementation in `src/common/zoitechat.c` including `zoitechat_theme_import`, archive extraction (uses `unzip`/`ditto` on Unix/macOS and `Expand-Archive` via PowerShell on Windows), theme basename/paths helpers, and `themes` inbox handling (`.imports`).
- Implement a queueing flow that copies startup theme files into an inbox and a directory monitor (GFileMonitor) that imports files placed into the inbox; add `theme_queue_import_file`, `theme_import_process_inbox`, and `theme_import_start_monitor` in `zoitechat.c`.
- On Windows add a named mutex (`ZoiteChat.ThemeImport`) that causes secondary launchers to copy theme files to the inbox and exit, letting the running instance import them (single-instance import behaviour).
- Route startup arguments through import logic: update `irc_init` and `main` in `src/common/zoitechat.c` to detect local `file://` and plain paths with `.zct`/`.hct` extensions and call `zoitechat_theme_import` or fall back to the previous `server`/`newserver` handling.
- Add a user command `/THEMEIMPORT` by introducing `cmd_themeimport` in `src/common/outbound.c` so themes can be imported on-demand via normal command handling.
- Update D-Bus remote handling in `src/common/dbus/dbus-client.c` so remote invocations route theme file arguments to a `themeimport` command when an instance is already running (preserves previous `url` routing for non-theme args).
- Expose `zoitechat_theme_import` in `src/common/zoitechat.h` and perform small robustness improvements to queued filenames and error reporting.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696af7f40bb4832d98010609a7350898)