### PR TITLE
Windows MSBuild: detect gvsbuild OpenSSL/Lua/zlib layouts

### DIFF
--- a/plugins/checksum/checksum.vcxproj
+++ b/plugins/checksum/checksum.vcxproj
@@ -30,7 +30,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;CHECKSUM_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(DepsRoot)\include;$(Glib);..\..\src\common;$(ZoiteChatLib);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(DepsRoot)\include;$(OpenSslInclude);$(Glib);..\..\src\common;$(ZoiteChatLib);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <ModuleDefinitionFile>checksum.def</ModuleDefinitionFile>
@@ -41,7 +41,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <PreprocessorDefinitions>WIN32;_WIN64;_AMD64_;NDEBUG;_WINDOWS;_USRDLL;CHECKSUM_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(DepsRoot)\include;$(Glib);..\..\src\common;$(ZoiteChatLib);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(DepsRoot)\include;$(OpenSslInclude);$(Glib);..\..\src\common;$(ZoiteChatLib);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <ModuleDefinitionFile>checksum.def</ModuleDefinitionFile>

--- a/plugins/fishlim/fishlim.vcxproj
+++ b/plugins/fishlim/fishlim.vcxproj
@@ -30,7 +30,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;FISHLIM_EXPORTS;HAVE_DH_SET0_PQG;HAVE_DH_GET0_KEY;HAVE_DH_SET0_KEY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(DepsRoot)\include;$(Glib);..\..\src\common;$(ZoiteChatLib);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(DepsRoot)\include;$(OpenSslInclude);$(Glib);..\..\src\common;$(ZoiteChatLib);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <ModuleDefinitionFile>fishlim.def</ModuleDefinitionFile>
@@ -41,7 +41,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <PreprocessorDefinitions>WIN32;_WIN64;_AMD64_;NDEBUG;_WINDOWS;_USRDLL;FISHLIM_EXPORTS;HAVE_DH_SET0_PQG;HAVE_DH_GET0_KEY;HAVE_DH_SET0_KEY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(DepsRoot)\include;$(Glib);..\..\src\common;$(ZoiteChatLib);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(DepsRoot)\include;$(OpenSslInclude);$(Glib);..\..\src\common;$(ZoiteChatLib);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <ModuleDefinitionFile>fishlim.def</ModuleDefinitionFile>

--- a/plugins/sysinfo/sysinfo.vcxproj
+++ b/plugins/sysinfo/sysinfo.vcxproj
@@ -31,7 +31,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;SYSINFO_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\src\common;$(DepsRoot)\include;$(Glib);$(ZoiteChatLib);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\common;$(DepsRoot)\include;$(OpenSslInclude);$(Glib);$(ZoiteChatLib);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
     </ClCompile>
     <Link>
@@ -44,7 +44,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <PreprocessorDefinitions>WIN32;_WIN64;_AMD64_;NDEBUG;_WINDOWS;_USRDLL;SYSINFO_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\src\common;$(DepsRoot)\include;$(Glib);$(ZoiteChatLib);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\common;$(DepsRoot)\include;$(OpenSslInclude);$(Glib);$(ZoiteChatLib);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
     </ClCompile>
     <Link>

--- a/plugins/winamp/winamp.vcxproj
+++ b/plugins/winamp/winamp.vcxproj
@@ -39,7 +39,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(DepsRoot)\include;$(Glib);..\..\src\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(DepsRoot)\include;$(OpenSslInclude);$(Glib);..\..\src\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <ModuleDefinitionFile>winamp.def</ModuleDefinitionFile>

--- a/src/common/common.vcxproj
+++ b/src/common/common.vcxproj
@@ -99,13 +99,13 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;$(OwnFlags);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ZoiteChatLib);$(DepsRoot)\include;$(Glib);$(Gtk);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ZoiteChatLib);$(DepsRoot)\include;$(OpenSslInclude);$(Glib);$(Gtk);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <PreprocessorDefinitions>WIN32;_WIN64;_AMD64_;NDEBUG;_LIB;$(OwnFlags);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ZoiteChatLib);$(DepsRoot)\include;$(Glib);$(Gtk);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ZoiteChatLib);$(DepsRoot)\include;$(OpenSslInclude);$(Glib);$(Gtk);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4267;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
   </ItemDefinitionGroup>

--- a/src/fe-gtk/fe-gtk.vcxproj
+++ b/src/fe-gtk/fe-gtk.vcxproj
@@ -30,7 +30,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;$(OwnFlags);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\common;$(ZoiteChatLib);$(DepsRoot)\include;$(Glib);$(Gtk);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\common;$(ZoiteChatLib);$(DepsRoot)\include;$(OpenSslInclude);$(Glib);$(Gtk);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4244;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
@@ -42,7 +42,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <PreprocessorDefinitions>WIN32;_WIN64;_AMD64_;NDEBUG;_WINDOWS;$(OwnFlags);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\common;$(ZoiteChatLib);$(DepsRoot)\include;$(Glib);$(Gtk);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\common;$(ZoiteChatLib);$(DepsRoot)\include;$(OpenSslInclude);$(Glib);$(Gtk);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4244;4267;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>

--- a/src/fe-text/fe-text.vcxproj
+++ b/src/fe-text/fe-text.vcxproj
@@ -30,7 +30,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;$(OwnFlags);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ZoiteChatLib);$(DepsRoot)\include;$(Glib);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ZoiteChatLib);$(DepsRoot)\include;$(OpenSslInclude);$(Glib);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -44,7 +44,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <PreprocessorDefinitions>WIN32;_WIN64;_AMD64_;NDEBUG;_CONSOLE;$(OwnFlags);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(ZoiteChatLib);$(DepsRoot)\include;$(Glib);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ZoiteChatLib);$(DepsRoot)\include;$(OpenSslInclude);$(Glib);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/libenchant_win8/libenchant_win8.vcxproj
+++ b/src/libenchant_win8/libenchant_win8.vcxproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>..\common;$(ZoiteChatLib);$(DepsRoot)\include\enchant;$(DepsRoot)\include;$(Glib);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\common;$(ZoiteChatLib);$(DepsRoot)\include\enchant;$(DepsRoot)\include;$(OpenSslInclude);$(Glib);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies>$(DepLibs);%(AdditionalDependencies)</AdditionalDependencies>

--- a/win32/zoitechat.props
+++ b/win32/zoitechat.props
@@ -26,10 +26,13 @@
 		<Python3Path>$(YourPython3Path)\$(PlatformName)</Python3Path>
 		<Python3Lib>python314</Python3Lib>
 		<Python3Output>hcpython3</Python3Output>
-		<LuaInclude>$(DepsRoot)\include\luajit-2.1;$(DepsRoot)\include\lua;$(DepsRoot)\include\lua5.1;$(SolutionDir)..\plugins\lua\luajit\src;$(SolutionDir)..\plugins\lua\luajit\src\jit</LuaInclude>
+		<LuaInclude>$(DepsRoot)\include\luajit-2.1;$(DepsRoot)\include\lua;$(DepsRoot)\include\lua5.1;$(DepsRoot)\include\lua54;$(DepsRoot)\include\lua5.4;$(DepsRoot)\include\lua-5.4;$(SolutionDir)..\plugins\lua\luajit\src;$(SolutionDir)..\plugins\lua\luajit\src\jit</LuaInclude>
 		<LuaOutput>hclua</LuaOutput>
 		<LuaLib Condition="Exists('$(DepsRoot)\\lib\\lua51.lib')">lua51</LuaLib>
 		<LuaLib Condition="'$(LuaLib)'=='' and Exists('$(DepsRoot)\\lib\\lua5.1.lib')">lua5.1</LuaLib>
+		<LuaLib Condition="'$(LuaLib)'=='' and Exists('$(DepsRoot)\\lib\\lua54.lib')">lua54</LuaLib>
+		<LuaLib Condition="'$(LuaLib)'=='' and Exists('$(DepsRoot)\\lib\\lua5.4.lib')">lua5.4</LuaLib>
+		<LuaLib Condition="'$(LuaLib)'=='' and Exists('$(DepsRoot)\\lib\\lua-5.4.lib')">lua-5.4</LuaLib>
 		<LuaLib Condition="'$(LuaLib)'=='' and Exists('$(DepsRoot)\\lib\\lua.lib')">lua</LuaLib>
 		<LuaLib Condition="'$(LuaLib)'==''">lua51</LuaLib>
 		<Glib>$(DepsRoot)\include\glib-2.0;$(DepsRoot)\lib\glib-2.0\include;$(DepsRoot)\include\libxml2</Glib>
@@ -42,20 +45,33 @@
         <XmlLib Condition="Exists('$(DepsRoot)\\lib\\libxml2-2.0.lib')">libxml2-2.0.lib</XmlLib>
         <XmlLib Condition="'$(XmlLib)'==''">libxml2.lib</XmlLib>
         <SslLib Condition="Exists('$(DepsRoot)\\lib\\libssl.lib')">libssl.lib</SslLib>
+        <SslLib Condition="'$(SslLib)'=='' and Exists('$(DepsRoot)\\lib\\libssl-3-x64.lib')">libssl-3-x64.lib</SslLib>
+        <SslLib Condition="'$(SslLib)'=='' and Exists('$(DepsRoot)\\lib\\libssl-3-x86.lib')">libssl-3-x86.lib</SslLib>
+        <SslLib Condition="'$(SslLib)'=='' and Exists('$(DepsRoot)\\lib\\libssl-3.lib')">libssl-3.lib</SslLib>
         <SslLib Condition="'$(SslLib)'=='' and Exists('$(DepsRoot)\\lib\\ssl.lib')">ssl.lib</SslLib>
         <CryptoLib Condition="Exists('$(DepsRoot)\\lib\\libcrypto.lib')">libcrypto.lib</CryptoLib>
+        <CryptoLib Condition="'$(CryptoLib)'=='' and Exists('$(DepsRoot)\\lib\\libcrypto-3-x64.lib')">libcrypto-3-x64.lib</CryptoLib>
+        <CryptoLib Condition="'$(CryptoLib)'=='' and Exists('$(DepsRoot)\\lib\\libcrypto-3-x86.lib')">libcrypto-3-x86.lib</CryptoLib>
+        <CryptoLib Condition="'$(CryptoLib)'=='' and Exists('$(DepsRoot)\\lib\\libcrypto-3.lib')">libcrypto-3.lib</CryptoLib>
         <CryptoLib Condition="'$(CryptoLib)'=='' and Exists('$(DepsRoot)\\lib\\crypto.lib')">crypto.lib</CryptoLib>
         <SslLegacyLib Condition="Exists('$(DepsRoot)\\lib\\ssleay32.lib')">ssleay32.lib</SslLegacyLib>
         <CryptoLegacyLib Condition="Exists('$(DepsRoot)\\lib\\libeay32.lib')">libeay32.lib</CryptoLegacyLib>
+        <OpenSslInclude Condition="Exists('$(DepsRoot)\\include\\openssl\\ssl.h')">$(DepsRoot)\include</OpenSslInclude>
+        <OpenSslInclude Condition="'$(OpenSslInclude)'=='' and Exists('$(DepsRoot)\\include\\openssl3\\openssl\\ssl.h')">$(DepsRoot)\include\openssl3</OpenSslInclude>
+        <OpenSslInclude Condition="'$(OpenSslInclude)'=='' and Exists('$(DepsRoot)\\include\\openssl-3\\openssl\\ssl.h')">$(DepsRoot)\include\openssl-3</OpenSslInclude>
+        <ZlibLib Condition="Exists('$(DepsRoot)\\lib\\zlib.lib')">zlib.lib</ZlibLib>
+        <ZlibLib Condition="'$(ZlibLib)'=='' and Exists('$(DepsRoot)\\lib\\zlib1.lib')">zlib1.lib</ZlibLib>
+        <ZlibLib Condition="'$(ZlibLib)'=='' and Exists('$(DepsRoot)\\lib\\zlibstatic.lib')">zlibstatic.lib</ZlibLib>
+        <ZlibLib Condition="'$(ZlibLib)'==''">zlib.lib</ZlibLib>
 
-        <Gtk2Libs>gtk-win32-2.0.lib;gdk-win32-2.0.lib;atk-1.0.lib;gio-2.0.lib;gdk_pixbuf-2.0.lib;pangowin32-1.0.lib;pangocairo-1.0.lib;pango-1.0.lib;cairo.lib;gobject-2.0.lib;gmodule-2.0.lib;glib-2.0.lib;intl.lib;iconv.lib;zlib.lib;$(XmlLib);libjpeg.lib;libpng16.lib;$(CryptoLib);$(SslLib);$(CryptoLegacyLib);$(SslLegacyLib)</Gtk2Libs>
+        <Gtk2Libs>gtk-win32-2.0.lib;gdk-win32-2.0.lib;atk-1.0.lib;gio-2.0.lib;gdk_pixbuf-2.0.lib;pangowin32-1.0.lib;pangocairo-1.0.lib;pango-1.0.lib;cairo.lib;gobject-2.0.lib;gmodule-2.0.lib;glib-2.0.lib;intl.lib;iconv.lib;$(ZlibLib);$(XmlLib);libjpeg.lib;libpng16.lib;$(CryptoLib);$(SslLib);$(CryptoLegacyLib);$(SslLegacyLib)</Gtk2Libs>
         <Gtk3Lib Condition="Exists('$(DepsRoot)\\lib\\gtk-3.0.lib')">gtk-3.0.lib</Gtk3Lib>
         <Gtk3Lib Condition="'$(Gtk3Lib)'=='' and Exists('$(DepsRoot)\\lib\\gtk-3.lib')">gtk-3.lib</Gtk3Lib>
         <Gtk3Lib Condition="'$(Gtk3Lib)'=='' and Exists('$(DepsRoot)\\lib\\gtk-3-0.lib')">gtk-3-0.lib</Gtk3Lib>
         <Gdk3Lib Condition="Exists('$(DepsRoot)\\lib\\gdk-3.0.lib')">gdk-3.0.lib</Gdk3Lib>
         <Gdk3Lib Condition="'$(Gdk3Lib)'=='' and Exists('$(DepsRoot)\\lib\\gdk-3.lib')">gdk-3.lib</Gdk3Lib>
         <Gdk3Lib Condition="'$(Gdk3Lib)'=='' and Exists('$(DepsRoot)\\lib\\gdk-3-0.lib')">gdk-3-0.lib</Gdk3Lib>
-        <Gtk3Libs>$(Gtk3Lib);$(Gdk3Lib);atk-1.0.lib;gio-2.0.lib;gdk_pixbuf-2.0.lib;pangowin32-1.0.lib;pangocairo-1.0.lib;pango-1.0.lib;cairo.lib;gobject-2.0.lib;gmodule-2.0.lib;glib-2.0.lib;intl.lib;iconv.lib;zlib.lib;$(XmlLib);libjpeg.lib;libpng16.lib;$(CryptoLib);$(SslLib)</Gtk3Libs>
+        <Gtk3Libs>$(Gtk3Lib);$(Gdk3Lib);atk-1.0.lib;gio-2.0.lib;gdk_pixbuf-2.0.lib;pangowin32-1.0.lib;pangocairo-1.0.lib;pango-1.0.lib;cairo.lib;gobject-2.0.lib;gmodule-2.0.lib;glib-2.0.lib;intl.lib;iconv.lib;$(ZlibLib);$(XmlLib);libjpeg.lib;libpng16.lib;$(CryptoLib);$(SslLib)</Gtk3Libs>
 
         <DepLibs Condition="'$(UsingGtk3)'=='true'">$(Gtk3Libs);wininet.lib;winmm.lib;ws2_32.lib</DepLibs>
         <DepLibs Condition="'$(UsingGtk3)'!='true'">$(Gtk2Libs);wininet.lib;winmm.lib;ws2_32.lib</DepLibs>


### PR DESCRIPTION
### Motivation
- The Windows MSBuild projects could not find headers/libs from gvsbuild layouts (missing `lua.h`, `openssl/ssl.h`, `zlib.lib`), so the build needs expanded detection of common gvsbuild file/layout variants and explicit OpenSSL include wiring.

### Description
- Expand Lua detection in `win32/zoitechat.props` by adding `lua54`/`lua5.4`/`lua-5.4` include paths and library conditions for `lua54`/`lua5.4`/`lua-5.4`.
- Add broader OpenSSL library detection (`libssl-3*`, `libcrypto-3*`, and fallback names) and introduce an `OpenSslInclude` variable that points to the correct OpenSSL include directory.
- Add `ZlibLib` detection for common zlib lib names and use `$(ZlibLib)` in the GTK2/GTK3 dependency lists so `zlib` is picked up from gvsbuild layouts.
- Inject `$(OpenSslInclude)` into `AdditionalIncludeDirectories` for core targets and plugins so projects can locate `openssl/ssl.h` without manual per-project edits; files updated: `win32/zoitechat.props`, `src/common/common.vcxproj`, `src/fe-gtk/fe-gtk.vcxproj`, `src/fe-text/fe-text.vcxproj`, `plugins/checksum/checksum.vcxproj`, `plugins/fishlim/fishlim.vcxproj`, `plugins/sysinfo/sysinfo.vcxproj`, `plugins/winamp/winamp.vcxproj`, and `src/libenchant_win8/libenchant_win8.vcxproj`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698251a72cfc832da4f79dfd44a61690)