### PR TITLE
Updated the Solus package release from 2 to 3 to publish this packagi…

### DIFF
--- a/packaging/solus/package.yml
+++ b/packaging/solus/package.yml
@@ -1,6 +1,6 @@
 name       : zoitechat
 version    : 2.18.0
-release    : 2
+release    : 3
 source     :
     - https://github.com/ZoiteChat/zoitechat/archive/e060d57baee1be22bee1f9c3b047be3fa71c6d35.tar.gz : ed315a0b1c46e798912fd830d3845427972857c43ccaa16284969c6f542add38
 homepage   : https://zoitechat.zoite.net/
@@ -22,6 +22,7 @@ builddeps  :
     - ninja
     - pkgconf
     - gcc
+    - binutils
     - gettext
 setup      : |
     %meson_configure \


### PR DESCRIPTION
…ng fix.

Added binutils to Solus builddeps so the GNU linker (ld) is available during Meson toolchain detection.