### PR TITLE
Updated Linux URL launching in fe_open_url_inner to capture gtk_show_…

### DIFF
--- a/src/fe-gtk/fe-gtk.c
+++ b/src/fe-gtk/fe-gtk.c
@@ -1693,11 +1693,13 @@ fe_open_url_inner (const char *url)
 	{
 		gchar **tmp_env = spawn_env;
 		spawn_env = g_environ_unsetenv (tmp_env, "LD_LIBRARY_PATH");
-		g_strfreev (tmp_env);
+		if (spawn_env != tmp_env)
+			g_strfreev (tmp_env);
 
 		tmp_env = spawn_env;
 		spawn_env = g_environ_unsetenv (tmp_env, "LD_PRELOAD");
-		g_strfreev (tmp_env);
+		if (spawn_env != tmp_env)
+			g_strfreev (tmp_env);
 	}
 
 	/* Prefer xdg-open when available because gtk_show_uri can inherit


### PR DESCRIPTION
…uri errors instead of discarding them, so failures are no longer silent.

Added an xdg-open fallback path when gtk_show_uri fails, which improves behavior in AppImage/sandbox-like environments where GTK/GIO handler resolution can fail. Added warning logs for both the primary gtk_show_uri failure and fallback failure to make future debugging much easier.