### PR TITLE
fix(python): concatenate bytes in compile_line of py console

### DIFF
--- a/plugins/python/python.py
+++ b/plugins/python/python.py
@@ -320,9 +320,9 @@ def _on_say_command(word, word_eol, userdata):
         return 0
 
     try:
-        python = _cstr(word_eol[1])
+        python = __decode(_cstr(word_eol[1]))
     except Exception:
-        python = b''
+        python = ''
 
     if not python:
         return 1


### PR DESCRIPTION
This fixes python console. I'm not sure which python version broke it. I have 3.14.4. But I think it is a safe fix that should work with earlier versions as well.
Trying to execute anything within `/py console` yields:
```
 Traceback (most recent call last):
   File "<init code for '_zoitechat_embedded'>", line 331, in _on_say_command
   File "<init code for '_zoitechat_embedded'>", line 437, in exec_in_interp
   File "<init code for '_zoitechat_embedded'>", line 115, in compile_line
 TypeError: can't concat str to bytes
```