### PR TITLE
Fix private messages splitting into two windows over WeeChat's IRC relay

### DIFF
--- a/src/common/ctcp.c
+++ b/src/common/ctcp.c
@@ -126,7 +126,21 @@ ctcp_handle (session *sess, char *to, char *nick, char *ip,
 		if (ctcp_check (sess, nick, word, word_eol, word[4] + ctcp_offset))
 			goto generic;
 
-		inbound_action (sess, to, nick, ip, msg + 7, FALSE, tags_data->identified, tags_data);
+		{
+			gboolean fromme = !serv->p_cmp (nick, serv->nick);
+
+			if (fromme && !is_channel (serv, to))
+			{
+				session *target = find_dialog (serv, to);
+
+				if (target)
+					sess = target;
+				else if (serv->front_session)
+					sess = serv->front_session;
+			}
+
+			inbound_action (sess, to, nick, ip, msg + 7, fromme, tags_data->identified, tags_data);
+		}
 		return;
 	}
 

--- a/src/common/proto-irc.c
+++ b/src/common/proto-irc.c
@@ -1368,7 +1368,7 @@ process_named_msg (session *sess, char *type, char *word[], char *word_eol[],
 						{
 							if (ignore_check (word[1], IG_PRIV))
 								return;
-							if (serv->have_echo_message && !serv->p_cmp (nick, serv->nick))
+							if (!serv->p_cmp (nick, serv->nick))
 							{
 								session *target_sess = find_dialog (serv, to);
 


### PR DESCRIPTION
## What's wrong

If you connect through WeeChat's IRC relay, private messages you send show up in a conversation window under your own nickname, while the replies from the other person show up in a *different* window under their nickname. So instead of one back-and-forth conversation, you get two separate one-sided windows.

This doesn't happen with ZNC or connecting directly to a server — only through WeeChat's relay.

## Why it happens

When you send someone a private message, some servers echo that message straight back to you, so ZoiteChat can display it in your conversation window as "sent." To recognize that this echoed message is really your own, ZoiteChat only trusted a small feature called `echo-message`, confirmed by the server when you connect.

WeeChat's relay simply never offers that feature at all. Here's what it announces on connect:

```
* Connected. Now logging in.
* Capabilities supported: server-time
* Capabilities requested: server-time
* Capabilities acknowledged: server-time
```

Only `server-time` — no `echo-message`, ever. So ZoiteChat could never recognize its own echoed message as its own over this relay, no matter what. It ends up treating it as a brand new message arriving from "yourself," and opens a new window for it instead of using the conversation window you were already typing in.

## The fix

Instead of only trusting that feature announcement, ZoiteChat now also checks who actually sent the message. If a message is confirmed to have come from you, it's routed into the same conversation window you sent it from — regardless of whether the server/relay ever announces support for that feature.

## Testing

Confirmed this resolves the split-window behavior when connecting through a WeeChat relay. Servers/bouncers that already worked correctly (tested with ZNC) are unaffected, since this only changes how a message from yourself is routed, not whether it's detected as one.